### PR TITLE
Prevent unneeded vertical tick where there's only one child

### DIFF
--- a/process_diagram.css
+++ b/process_diagram.css
@@ -60,6 +60,8 @@
 .process_diagram ul > li:first-child:after {top:50%; bottom:auto; height:50%; }
 .process_diagram ul > li:last-child:before,
 .process_diagram ul > li:last-child:after {top:0; bottom:auto; height:50%;}
+.process_diagram ul > li:first-child:last-child:before,
+.process_diagram ul > li:first-child:last-child:after {top:0; bottom:auto; height:50%;}
 
 /* put left and right dashes */
 .process_diagram li > div {position:relative; margin:0 var(--linewidth); padding: 1em; border-width:var(--linethick); }


### PR DESCRIPTION
Uses first-child:last-child to ensure that were there's only one child node there isn't an unnecessary vertical line. Didn't use only-child as it's unsupported in Safari.